### PR TITLE
توحيد رابط الموقع على cloudmenuy.netlify.app بمصدر واحد (SITE_URL)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,8 @@
 - **المصدر الحيّ الوحيد هو تطبيق Next.js في `web/`.** مبني بـ **Next.js 16 + React 19 +
   Tailwind 4 + Supabase SSR**، منظّم بمكوّنات وصفحات وserver actions قابلة للقراءة والتطوير.
 - **النشر:** Netlify مربوط بـ Git، يبني من `web/` تلقائياً (`netlify.toml` بالجذر: `base="web"`).
-  الدومين: `https://cloudsmenu.netlify.app/`.
+  الدومين الحالي: `https://cloudmenuy.netlify.app/` (مؤقت حتى شراء دومين رسمي —
+  عند التغيير عدّل `SITE_URL` في `web/src/lib/site.ts` فقط).
 - **الأرشيف:** النسخة القديمة كانت ملف HTML واحد مصغّر (~1.49MB) يُنشر يدوياً. أُرشِف في
   `legacy/public/index.html` ولم يعد يُطوَّر أو يُنشر. لا تعدّله؛ استخدمه للمرجع فقط.
 - اللغة: عربية RTL، خطوط Google (Cairo, Tajawal, …).

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ npm run dev
    Netlify → Site settings → Environment variables:
    `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `FOUNDER_EMAIL`,
    `NEXT_PUBLIC_MOYASAR_PK`.
-2. تأكّد أن الدومين `cloudsmenu.netlify.app` يشير إلى الموقع المبني من Git.
+2. الدومين الحالي: `cloudmenuy.netlify.app` (مؤقت حتى شراء دومين رسمي).
+   عند تغيير الدومين مستقبلاً: عدّل `SITE_URL` في `web/src/lib/site.ts` فقط —
+   كل شيء (metadata، sitemap، robots، أكواد QR، الروابط) يشتق منه.
 
 ## التحقق قبل أي push
 

--- a/web/src/app/[slug]/page.tsx
+++ b/web/src/app/[slug]/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getPublicMenu, getRestaurantBySlug } from "@/lib/data";
 import { getSiteSettings } from "@/lib/settings";
+import { SITE_URL } from "@/lib/site";
 import { getTheme } from "@/lib/themes";
 import { MenuBody } from "@/components/menu/menu-body";
 import { SocialLinks } from "@/components/menu/social-links";
@@ -129,7 +130,7 @@ export default async function MenuPage({ params }: Params) {
       {/* Footer */}
       <footer className="border-t py-6 text-center" style={{ borderColor: "var(--m-border)" }}>
         <a
-          href="https://cloudsmenu.netlify.app"
+          href={SITE_URL}
           target="_blank"
           rel="noreferrer"
           className="text-xs font-semibold opacity-70 transition-opacity hover:opacity-100"

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import { Cairo, Tajawal, Reem_Kufi, Amiri } from "next/font/google";
 import { RegisterSW } from "@/components/site/register-sw";
+import { SITE_URL } from "@/lib/site";
 import "./globals.css";
 
 const cairo = Cairo({
@@ -30,8 +31,6 @@ const amiri = Amiri({
   variable: "--font-amiri",
   display: "swap",
 });
-
-const SITE_URL = "https://cloudsmenu.netlify.app";
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),

--- a/web/src/app/robots.ts
+++ b/web/src/app/robots.ts
@@ -1,8 +1,9 @@
 import type { MetadataRoute } from "next";
+import { SITE_URL } from "@/lib/site";
 
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: { userAgent: "*", allow: "/" },
-    sitemap: "https://cloudsmenu.netlify.app/sitemap.xml",
+    sitemap: `${SITE_URL}/sitemap.xml`,
   };
 }

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -1,9 +1,10 @@
 import type { MetadataRoute } from "next";
+import { SITE_URL } from "@/lib/site";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   return [
     {
-      url: "https://cloudsmenu.netlify.app/",
+      url: `${SITE_URL}/`,
       changeFrequency: "weekly",
       priority: 1,
     },

--- a/web/src/components/dashboard/qr-studio.tsx
+++ b/web/src/components/dashboard/qr-studio.tsx
@@ -6,6 +6,7 @@ import { Download } from "lucide-react";
 import { Field, Input } from "@/components/ui/field";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import { SITE_URL } from "@/lib/site";
 
 export function QrStudio({ slug }: { slug: string }) {
   const [table, setTable] = useState("");
@@ -13,9 +14,7 @@ export function QrStudio({ slug }: { slug: string }) {
 
   const url = useMemo(() => {
     const origin =
-      typeof window !== "undefined"
-        ? window.location.origin
-        : "https://cloudsmenu.netlify.app";
+      typeof window !== "undefined" ? window.location.origin : SITE_URL;
     const base = `${origin}/${slug}`;
     return table.trim() ? `${base}?table=${encodeURIComponent(table.trim())}` : base;
   }, [slug, table]);

--- a/web/src/components/dashboard/restaurant-onboarding.tsx
+++ b/web/src/components/dashboard/restaurant-onboarding.tsx
@@ -5,6 +5,9 @@ import { createRestaurant, type ActionState } from "@/app/dashboard/actions";
 import { Field, Input } from "@/components/ui/field";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import { SITE_URL } from "@/lib/site";
+
+const SITE_HOST = SITE_URL.replace(/^https?:\/\//, "");
 
 export function RestaurantOnboarding() {
   const [state, action, pending] = useActionState<ActionState, FormData>(
@@ -29,7 +32,7 @@ export function RestaurantOnboarding() {
           <Field
             label="رابط المطعم (slug)"
             htmlFor="slug"
-            hint="سيظهر في الرابط: cloudsmenu.netlify.app/your-slug"
+            hint={`سيظهر في الرابط: ${SITE_HOST}/your-slug`}
           >
             <Input id="slug" name="slug" dir="ltr" placeholder="al-thawaqa" />
           </Field>

--- a/web/src/lib/site.ts
+++ b/web/src/lib/site.ts
@@ -1,0 +1,6 @@
+/**
+ * رابط الموقع الرسمي — المصدر الوحيد في كل الكود.
+ * عند شراء دومين رسمي: غيّر هذا السطر فقط وسيتحدّث كل شيء
+ * (metadata/OG، sitemap، robots، أكواد QR، روابط التذييل).
+ */
+export const SITE_URL = "https://cloudmenuy.netlify.app";


### PR DESCRIPTION
## الهدف
اعتماد `https://cloudmenuy.netlify.app` رابطاً رسمياً مؤقتاً (حتى شراء دومين)، وتوحيد كل استخداماته في ثابت واحد.

## التغييرات
- ملف جديد `web/src/lib/site.ts` يصدّر `SITE_URL` — المصدر الوحيد للرابط.
- اشتقاق كل الاستخدامات منه: metadata/OpenGraph (`layout.tsx`)، `sitemap.ts`، `robots.ts`، أكواد QR (`qr-studio.tsx`)، تذييل صفحة المنيو العامة، وتلميح إنشاء المطعم.
- تحديث `CLAUDE.md` و`README.md`: عند شراء الدومين الرسمي يكفي تعديل سطر `SITE_URL` واحد.

## التحقق
- `next build` + `tsc --noEmit` + `lint` = صفر أخطاء، ولا بقايا للرابط القديم في `web/src`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015Kqe3vZyADjEBUMSdPYpHM)_